### PR TITLE
test(): set-up jest with ts + fix error on regex

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
+coverage/
 node_modules/
+package-lock.json
 yarn-error.log

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  collectCoverage: true,
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+};

--- a/package.json
+++ b/package.json
@@ -15,12 +15,15 @@
   },
   "devDependencies": {
     "@types/globby": "^8.0.0",
+    "@types/jest": "^24.0.18",
     "@types/meow": "^5.0.0",
     "husky": "^1.3.1",
+    "jest": "^24.9.0",
+    "ts-jest": "^24.1.0",
     "tslint": "^5.12.0"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 0",
+    "test": "jest",
     "tslint": "tslint -c tslint.json -p tsconfig.json --fix",
     "build": "tsc",
     "dev": "tsc -w"

--- a/src/__mocks__/fs.js
+++ b/src/__mocks__/fs.js
@@ -1,0 +1,55 @@
+'use strict';
+
+const fs = jest.genMockFromModule('fs')
+
+const readdirMock = jest.fn()
+function __getReaddirMock() {
+    return readdirMock
+}
+function readdir(filePath, options, callback) {
+    return readdirMock(filePath, options, callback)
+}
+fs.__getReaddirMock = __getReaddirMock
+fs.readdir = readdir
+
+const statMock = jest.fn()
+function __getStatMock() {
+    return statMock
+}
+function stat(filePath, callback) {
+    return statMock(filePath, callback)
+}
+fs.__getStatMock = __getStatMock
+fs.stat = stat
+
+const readFileMock = jest.fn()
+function __getReadFileMock() {
+    return readFileMock
+}
+function readFile(filePath, callback) {
+    return readFileMock(filePath, callback)
+}
+fs.__getReadFileMock = __getReadFileMock
+fs.readFile = readFile
+
+const existsSyncMock = jest.fn()
+function __getExistsSyncMock() {
+    return existsSyncMock
+}
+function existsSync(filePath) {
+    return existsSyncMock(filePath)
+}
+fs.__getExistsSyncMock = __getExistsSyncMock
+fs.existsSync = existsSync
+
+const unlinkSyncMock = jest.fn()
+function __getUnlinkSyncMock() {
+    return unlinkSyncMock
+}
+function unlinkSync(filePath) {
+    return unlinkSyncMock(filePath)
+}
+fs.__getUnlinkSyncMock = __getUnlinkSyncMock
+fs.unlinkSync = unlinkSync
+
+module.exports = fs

--- a/src/__mocks__/path.js
+++ b/src/__mocks__/path.js
@@ -1,0 +1,15 @@
+'use strict';
+
+const path = jest.genMockFromModule('path')
+
+const resolveMock = jest.fn()
+function __getResolveMock() {
+    return resolveMock;
+}
+function resolve(...pathSegment) {
+    return resolveMock(pathSegment)
+}
+path.__getResolveMock = __getResolveMock
+path.resolve = resolve
+
+module.exports = path

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -1,0 +1,64 @@
+jest.mock('fs');
+
+import { removeSameNameJs } from './index';
+
+const fsMock = require('fs');
+
+describe('index functions', () => {
+  describe('removeSameNameJs function', () => {
+    const extArray = ['.js'];
+
+    beforeEach(() => {
+      fsMock.__getExistsSyncMock().mockReset();
+    });
+
+    it('should not clean when non typescript file', () => {
+      // Given-When
+      const result = removeSameNameJs('MyScript.txt', extArray);
+
+      // Then
+      expect(result).toEqual([]);
+      expect(fsMock.__getExistsSyncMock()).not.toHaveBeenCalled();
+      expect(fsMock.__getUnlinkSyncMock()).not.toHaveBeenCalled();
+    });
+
+    it('should clean existing file with ts extension', () => {
+      // Given
+      fsMock.__getExistsSyncMock().mockReturnValue(true);
+
+      // When
+      const result = removeSameNameJs('MyScript.ts', extArray);
+
+      // Then
+      expect(result).toEqual(['MyScript.js']);
+      expect(fsMock.__getExistsSyncMock()).toHaveBeenCalledWith('MyScript.js');
+      expect(fsMock.__getUnlinkSyncMock()).toHaveBeenCalledWith('MyScript.js');
+    });
+
+    it('should clean files with tsx extension', () => {
+      // Given
+      fsMock.__getExistsSyncMock().mockReturnValue(true);
+
+      // When
+      const result = removeSameNameJs('MyScript.tsx', extArray);
+
+      // Then
+      expect(result).toEqual(['MyScript.js']);
+      expect(fsMock.__getExistsSyncMock()).toHaveBeenCalledWith('MyScript.js');
+      expect(fsMock.__getUnlinkSyncMock()).toHaveBeenCalledWith('MyScript.js');
+    });
+
+    it('should clean files with ts extension and containing "ts" in name', () => {
+      // Given
+      fsMock.__getExistsSyncMock().mockReturnValue(true);
+
+      // When
+      const result = removeSameNameJs('MyScripts.tsx', extArray);
+
+      // Then
+      expect(result).toEqual(['MyScripts.js']);
+      expect(fsMock.__getExistsSyncMock()).toHaveBeenCalledWith('MyScripts.js');
+      expect(fsMock.__getUnlinkSyncMock()).toHaveBeenCalledWith('MyScripts.js');
+    });
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,7 +23,7 @@ export function removeSameNameJs(f: string, etxArr: string[]): string[] {
     return [];
   }
   return etxArr.map((item: string) => {
-    const jf = `${f.replace(/.tsx?/g, '')}${item}`;
+    const jf = `${f.replace(/\.tsx?/g, '')}${item}`;
     if (fs.existsSync(jf)) {
       fs.unlinkSync(jf);
       return jf;


### PR DESCRIPTION
Correctly cleans when 'ts' contained in file name